### PR TITLE
Adding in link to HipChat help doc explaining who can access 1-1 history and under what circumstances

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ HipChat is fantastic, however:
 
 4/25/2014: HipChat Changed Their TOS To Allow Admins Access to 1-1 Chat History
 
+4/27/2014: Response from HipChat regarding 1-1 chat access by admins - [Who can view chat history and files](http://help.hipchat.com/knowledgebase/articles/358098)
+
 Edit:
 5/22/2014: Having used Slack for a while, I hope HipChat improves! It's still a better experience than Slack, IMO. However, they really need to fix the multiple accounts/rooms issues.
 


### PR DESCRIPTION
Hey thanks for the great write-up on HipChat vs the competition.  I know a lot of people were upset about the TOS changes which on the surface sound pretty scary, but the reality is much less Big Brother and much more about offering admin access to those who want it not adding it for all.  Check out the help article which explains all the details.  Full disclosure, I work for Atlassian on the HipChat team :-)
