### PR TITLE
Glassboard out of business

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,3 @@ Features:
 [Partychat](http://partychapp.appspot.com/)
 
 [Campfire](https://campfirenow.com/)
-
-[Glassboard](http://glassboard.com/)
-


### PR DESCRIPTION
Glassboard shutdown in November 1st, 2014.

https://twitter.com/glassboard/status/521662105700028416